### PR TITLE
Make attack cost no xbot error message more clearer.

### DIFF
--- a/attackcost/attackcost.go
+++ b/attackcost/attackcost.go
@@ -39,7 +39,7 @@ func New(client *dcrd.Dcrd, webServer *web.Server, xcBot *exchanges.ExchangeBot)
 	}
 
 	if xcBot == nil {
-		return nil, errors.New("Attack cost requires exchange bot")
+		return nil, errors.New("Attack cost requires exchange bot, set 'exchange-monitor=1' to enable it.")
 	}
 
 	hash, err := client.Rpc.GetBestBlockHash()


### PR DESCRIPTION
This PR modifies the error messages shown when attack cost calculator is enabled and exchange monitor is disabled from `Attack cost requires exchange bot` to `Attack cost requires exchange bot, set 'exchange-monitor=1' to enable it.`