### PR TITLE
Staking reward input control update

### DIFF
--- a/attackcost/attackcost.go
+++ b/attackcost/attackcost.go
@@ -56,7 +56,7 @@ func New(client *dcrd.Dcrd, webServer *web.Server, xcBot *exchanges.ExchangeBot)
 	}
 
 	ac.server.AddMenuItem(web.MenuItem{
-		Href:      "/attack-cost",
+		Href:      "/attackcost",
 		HyperText: "Attack Cost",
 		Attributes: map[string]string{
 			"class": "menu-item",
@@ -68,7 +68,7 @@ func New(client *dcrd.Dcrd, webServer *web.Server, xcBot *exchanges.ExchangeBot)
 
 	ac.client.Notif.RegisterBlockHandlerGroup(ac.ConnectBlock)
 
-	ac.server.AddRoute("/attack-cost", web.GET, ac.attackCost)
+	ac.server.AddRoute("/attackcost", web.GET, ac.attackCost)
 	ac.server.AddRoute("/api/chart/market/{token}/depth", web.GET, ac.getMarketDepthChart, exchangeTokenContext)
 
 	return ac, nil

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -20,32 +20,33 @@
         </div>
         
         <div class="mb-3 bg-white p-3 pb-0">
-          <p class="m-0 desc" style="line-height: 30px;">
-            <span class="mr-2 d-sm-block">
+          <div class="row">
+            <div class="col-md-6 col-sm-15 d-flex mt-2">
               <span class="form-label">Amount (<span class="text-secondary">DCR</span>)</span>
               <input data-action="change->stakingreward#amountChanged"
                 data-action="keyup->staking#amountKeypress"
                 data-target="stakingreward.amount"
-                type="number" class="form-control amount mr-1" placeholder="Enter the amount of DCR to stake">
-            </span>
+                type="number" class="form-control amount mr-1" 
+                placeholder="Enter the amount of DCR to stake">
+            </div>
 
-            <span class="mr-2 d-sm-block">
+            <div class="col-md-5 col-sm-12 d-flex mt-2">
               <span class="form-label">Start</span>
               <input data-action="change->stakingreward#startDateChanged"
                 data-target="stakingreward.startDate"
                 type="date" class="form-control date mr-1" placeholder="Start Date"> 
-            </span>
-            
-            <span class="d-sm-block">
+            </div>
+
+            <div class="col-md-5 col-sm-12 d-flex mt-2">
               <span class="form-label">End</span>
               <input
                 data-action="change->stakingreward#endDateChanged"
                 data-target="stakingreward.endDate"
                     type="date"
                     class="form-control date" placeholder="End Date"> 
-            </span>
-            <br>
-
+            </div>
+          </div>
+          <p class="m-0 desc" style="line-height: 30px;">
             <span class="mr-3">
               <span class="form-label">Days</span>
               <span class="font-weight-bold" data-target="stakingreward.daysText">0</span>
@@ -56,7 +57,7 @@
               <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>
             </span>
 
-            <span>
+            <span class="d-block d-sm-inline">
               <span class="form-label">Reward</span>
               <span class="font-weight-bold" data-target="stakingreward.amountRoi">0</span>
               <span class="text-secondary">DCR</span>

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -33,6 +33,7 @@
             <div class="col-md-5 col-sm-12 d-flex mt-2">
               <span class="form-label">Start</span>
               <input data-action="change->stakingreward#startDateChanged"
+                data-action="keyup->staking#startDateKeypress"
                 data-target="stakingreward.startDate"
                 type="date" class="form-control date mr-1" placeholder="Start Date"> 
             </div>
@@ -41,6 +42,7 @@
               <span class="form-label">End</span>
               <input
                 data-action="change->stakingreward#endDateChanged"
+                data-action="keyup->staking#endDateKeypress"
                 data-target="stakingreward.endDate"
                     type="date"
                     class="form-control date" placeholder="End Date"> 

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -20,27 +20,47 @@
         </div>
         
         <div class="mb-3 bg-white p-3 pb-0">
-          <p class="m-0 desc" style="line-height: 30px;">This Calculator gives an estimate of your potential earning while staking your DCR on the network. <br>
-            Staking
-            <input data-action="change->stakingreward#amountChanged"
-              data-action="keyup->staking#amountKeypress"
-              data-target="stakingreward.amount"
-              type="number" class="form-control amount" placeholder="Enter the amount of DCR to stake">
-            <span class="text-secondary">DCR</span> from
-            <input data-action="change->stakingreward#startDateChanged"
-              data-target="stakingreward.startDate"
-              type="date" class="form-control date" placeholder="Start Date"> to 
-            <input
-              data-action="change->stakingreward#endDateChanged"
-              data-target="stakingreward.endDate"
-                  type="date"
-                   class="form-control date" placeholder="End Date"> <br>
-            will generate 
-            <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>% return on your 
-            investment 
-            in <span class="font-weight-bold" data-target="stakingreward.daysText">0</span> days which is
-            <span class="font-weight-bold" data-target="stakingreward.amountRoi">0</span>
-            <span class="text-secondary">DCR</span>.
+          <p class="m-0 desc" style="line-height: 30px;">
+            <span class="mr-2">
+              <span class="form-label">Amount (<span class="text-secondary">DCR</span>)</span>
+              <input data-action="change->stakingreward#amountChanged"
+                data-action="keyup->staking#amountKeypress"
+                data-target="stakingreward.amount"
+                type="number" class="form-control amount mr-1" placeholder="Enter the amount of DCR to stake">
+            </span>
+
+            <span class="mr-2">
+              <span class="form-label">Start</span>
+              <input data-action="change->stakingreward#startDateChanged"
+                data-target="stakingreward.startDate"
+                type="date" class="form-control date mr-1" placeholder="Start Date"> 
+            </span>
+            
+            <span>
+              <span class="form-label">End</span>
+              <input
+                data-action="change->stakingreward#endDateChanged"
+                data-target="stakingreward.endDate"
+                    type="date"
+                    class="form-control date" placeholder="End Date"> 
+            </span>
+            <br>
+
+            <span class="mr-4">
+              <span class="form-label">Days</span>
+              <span class="font-weight-bold" data-target="stakingreward.daysText">0</span>
+            </span>
+
+            <span class="mr-4">
+              <span class="form-label">% Return</span>
+              <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>
+            </span>
+
+            <span>
+              <span class="form-label">Reward</span>
+              <span class="font-weight-bold" data-target="stakingreward.amountRoi">0</span>
+              <span class="text-secondary">DCR</span>
+            </span>
           </p>
         </div>
 

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -21,7 +21,7 @@
         
         <div class="mb-3 bg-white p-3 pb-0">
           <p class="m-0 desc" style="line-height: 30px;">
-            <span class="mr-2">
+            <span class="mr-2 d-sm-block">
               <span class="form-label">Amount (<span class="text-secondary">DCR</span>)</span>
               <input data-action="change->stakingreward#amountChanged"
                 data-action="keyup->staking#amountKeypress"
@@ -29,14 +29,14 @@
                 type="number" class="form-control amount mr-1" placeholder="Enter the amount of DCR to stake">
             </span>
 
-            <span class="mr-2">
+            <span class="mr-2 d-sm-block">
               <span class="form-label">Start</span>
               <input data-action="change->stakingreward#startDateChanged"
                 data-target="stakingreward.startDate"
                 type="date" class="form-control date mr-1" placeholder="Start Date"> 
             </span>
             
-            <span>
+            <span class="d-sm-block">
               <span class="form-label">End</span>
               <input
                 data-action="change->stakingreward#endDateChanged"
@@ -46,12 +46,12 @@
             </span>
             <br>
 
-            <span class="mr-4">
+            <span class="mr-3">
               <span class="form-label">Days</span>
               <span class="font-weight-bold" data-target="stakingreward.daysText">0</span>
             </span>
 
-            <span class="mr-4">
+            <span class="mr-3">
               <span class="form-label">% Return</span>
               <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>
             </span>

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -56,7 +56,8 @@
 
             <span class="mr-3">
               <span class="form-label">Yield:</span>
-              <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>%
+              <span class="font-weight-bold" data-target="stakingreward.percentageRoi"
+                >0</span><span class="text-secondary">%</span>
             </span>
 
             <span class="d-block d-sm-inline">

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -56,7 +56,7 @@
 
             <span class="mr-3">
               <span class="form-label">Yield:</span>
-              <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>
+              <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>%
             </span>
 
             <span class="d-block d-sm-inline">

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -21,7 +21,7 @@
         
         <div class="mb-3 bg-white p-3 pb-0">
           <div class="row">
-            <div class="col-md-6 col-sm-15 d-flex mt-2">
+            <div class="col-md-7 col-sm-15 d-flex mt-2">
               <span class="form-label">Amount (<span class="text-secondary">DCR</span>)</span>
               <input data-action="change->stakingreward#amountChanged"
                 data-action="keyup->staking#amountKeypress"
@@ -30,7 +30,7 @@
                 placeholder="Enter the amount of DCR to stake">
             </div>
 
-            <div class="col-md-5 col-sm-12 d-flex mt-2">
+            <div class="col-md-6 col-sm-12 d-flex mt-2">
               <span class="form-label">Start</span>
               <input data-action="change->stakingreward#startDateChanged"
                 data-action="keyup->staking#startDateKeypress"
@@ -38,7 +38,7 @@
                 type="date" class="form-control date mr-1" placeholder="Start Date"> 
             </div>
 
-            <div class="col-md-5 col-sm-12 d-flex mt-2">
+            <div class="col-md-6 col-sm-12 d-flex mt-2">
               <span class="form-label">End</span>
               <input
                 data-action="change->stakingreward#endDateChanged"
@@ -50,17 +50,17 @@
           </div>
           <p class="m-0 desc" style="line-height: 30px;">
             <span class="mr-3">
-              <span class="form-label">Days</span>
+              <span class="form-label">Days:</span>
               <span class="font-weight-bold" data-target="stakingreward.daysText">0</span>
             </span>
 
             <span class="mr-3">
-              <span class="form-label">% Return</span>
+              <span class="form-label">Yield:</span>
               <span class="font-weight-bold" data-target="stakingreward.percentageRoi">0</span>
             </span>
 
             <span class="d-block d-sm-inline">
-              <span class="form-label">Reward</span>
+              <span class="form-label">Reward:</span>
               <span class="font-weight-bold" data-target="stakingreward.amountRoi">0</span>
               <span class="text-secondary">DCR</span>
             </span>

--- a/web/public/js/controllers/stakingreward_controller.js
+++ b/web/public/js/controllers/stakingreward_controller.js
@@ -44,8 +44,6 @@ export default class extends Controller {
   }
 
   amountKeypress (e) {
-    console.log(e.keyCode)
-    console.log(e)
     if (e.keyCode === 13) {
       this.amountChanged()
     }
@@ -56,16 +54,56 @@ export default class extends Controller {
     this.calculate()
   }
 
+  startDateKeypress (e) {
+    if (e.keyCode !== 13) {
+      return
+    }
+    if(!this.validateDate(true)) {
+      return
+    }
+    this.startDateChanged()
+  }
+
   startDateChanged () {
+    if(!this.validateDate()) {
+      return
+    }
     let startDateUnix = new Date(this.startDateTarget.value).getTime()
     insertOrUpdateQueryParam('start', startDateUnix, parseInt(this.last3Months.format('X')))
     this.calculate()
   }
 
+  endDateKeypress (e) {
+    if (e.keyCode !== 13) {
+      return
+    }
+    if(!this.validateDate(true)) {
+      return
+    }
+    this.endDateChanged()
+  }
+
   endDateChanged () {
+    if(!this.validateDate()) {
+      return
+    }
     let endDateUnix = new Date(this.endDateTarget.value).getTime()
     insertOrUpdateQueryParam('end', endDateUnix, parseInt(this.now.format('X')))
     this.calculate()
+  }
+
+  validateDate (showAlert) {
+    let startDate = moment(this.startDateTarget.value)
+    let endDate = moment(this.endDateTarget.value)
+
+    const days = moment.duration(endDate.diff(startDate)).asDays()
+    if (days < this.rewardPeriod) {
+      if(showAlert) {
+        window.alert(`You must stake for more than ${this.rewardPeriod} days`)
+      }
+      return false
+    }
+    return true
   }
 
   calculate () {

--- a/web/public/js/controllers/stakingreward_controller.js
+++ b/web/public/js/controllers/stakingreward_controller.js
@@ -58,14 +58,14 @@ export default class extends Controller {
     if (e.keyCode !== 13) {
       return
     }
-    if(!this.validateDate(true)) {
+    if (!this.validateDate(true)) {
       return
     }
     this.startDateChanged()
   }
 
   startDateChanged () {
-    if(!this.validateDate()) {
+    if (!this.validateDate()) {
       return
     }
     let startDateUnix = new Date(this.startDateTarget.value).getTime()
@@ -77,14 +77,14 @@ export default class extends Controller {
     if (e.keyCode !== 13) {
       return
     }
-    if(!this.validateDate(true)) {
+    if (!this.validateDate(true)) {
       return
     }
     this.endDateChanged()
   }
 
   endDateChanged () {
-    if(!this.validateDate()) {
+    if (!this.validateDate()) {
       return
     }
     let endDateUnix = new Date(this.endDateTarget.value).getTime()

--- a/web/public/js/utils.js
+++ b/web/public/js/utils.js
@@ -254,8 +254,8 @@ export function getParameterByName (name, url) {
 
 export function zipXYZData (gData, isHeightAxis, isDayBinned, yFormatter, zFormatter, windowS) {
   windowS = windowS || 1
-  yFormatter = yFormatter || 1
-  zFormatter = zFormatter || 1
+  yFormatter = yFormatter || function (d) { return d }
+  zFormatter = zFormatter || function (d) { return d }
   return map(gData.x, (n, i) => {
     let xAxisVal
     if (isHeightAxis && isDayBinned) {

--- a/web/public/scss/stakingreward.scss
+++ b/web/public/scss/stakingreward.scss
@@ -13,6 +13,7 @@
 
   p.desc {
     line-height: 22px;
+    font-size: 15px;
   }
 }
 
@@ -32,6 +33,7 @@
 
     p.desc {
       line-height: 30px;
+      font-size: 15px;
     }
   }
 }

--- a/web/public/scss/stakingreward.scss
+++ b/web/public/scss/stakingreward.scss
@@ -1,7 +1,12 @@
 .reward-calc {
+  .form-label {
+    line-height: 25px;
+    margin-right: 3px;
+  }
+
   .amount {
     display: inline-block !important;
-    width: 70px;
+    width: 90px;
     height: 25px;
   }
 
@@ -13,7 +18,6 @@
 
   p.desc {
     line-height: 22px;
-    font-size: 15px;
   }
 }
 
@@ -33,7 +37,6 @@
 
     p.desc {
       line-height: 30px;
-      font-size: 15px;
     }
   }
 }

--- a/web/public/scss/stakingreward.scss
+++ b/web/public/scss/stakingreward.scss
@@ -1,4 +1,6 @@
 .reward-calc {
+  font-size: 15px;
+
   .form-label {
     line-height: 25px;
     margin-right: 3px;
@@ -23,6 +25,8 @@
 
 @media (max-width: 320px) {
   .reward-calc {
+    font-size: 15px;
+
     .amount {
       display: inline-block !important;
       height: 25px;


### PR DESCRIPTION
Updated the layout of the staking reward input controls.
Changed the url of attack cost page to `attackcost`.
Updated the staking reward logic to only calculate when the user is done editing the fields