### PR TITLE
Fixed cache control

### DIFF
--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -6,7 +6,8 @@
     <meta name="description" content="Pdanalytics">
     <meta name="author" content="The Decred developers">
 
-	<meta name="turbolinks-cache-control" content="no-preview">
+	<meta name="turbolinks-cache-control" content="no-cache">
+	
     <title>{{ . }}</title>
 
     <link rel="shortcut icon" href="/images/logo.png" type="image/x-icon">

--- a/views/mempool.tmpl
+++ b/views/mempool.tmpl
@@ -4,7 +4,7 @@
 {{ template "html-head" "Mempool"}}
 
 <body data-controller="receive" class="{{ theme }}">
-<div class="body" data-controller="mempool" data-mempool-block-time="{{.BlockTime}}">
+<div class="body" data-controller="mempool" data-mempool-cached="0" data-mempool-block-time="{{.BlockTime}}">
     {{ template "navbar" . }}
     <div class="content">
         <div class="container-fluid">

--- a/web/public/js/controllers/commstat_controller.js
+++ b/web/public/js/controllers/commstat_controller.js
@@ -21,7 +21,6 @@ import TurboQuery from '../helpers/turbolinks_helper'
 
 const Dygraph = require('../vendor/dygraphs.min.js')
 
-let initialized = false
 const redditPlatform = 'Reddit'
 const twitterPlatform = 'Twitter'
 const githubPlatform = 'GitHub'
@@ -48,9 +47,11 @@ export default class extends Controller {
   }
 
   async initialize () {
-    if (initialized) {
-      return
-    }
+    // Turbolinks' cache control causes the initialize method to be fired multiple time
+    // because the preview is loaded first before the actual content is gotten from the
+    // server. If this is a preview, do nothing
+    if (this.data.get('cached') === '1') return
+    this.data.set('cached', '1')
 
     this.query = new TurboQuery()
     this.settings = TurboQuery.nullTemplate(['zoom', 'dataType'])

--- a/web/public/js/controllers/exchange_controller.js
+++ b/web/public/js/controllers/exchange_controller.js
@@ -15,7 +15,6 @@ import { animationFrame } from '../helpers/animation_helper'
 import TurboQuery from '../helpers/turbolinks_helper'
 
 const Dygraph = require('../vendor/dygraphs.min.js')
-let initialized = false
 
 export default class extends Controller {
   static get targets () {
@@ -30,10 +29,12 @@ export default class extends Controller {
   }
 
   connect () {
-    if (initialized) {
-      return
-    }
-    initialized = true
+    // Turbolinks' cache control causes the initialize method to be fired multiple time
+    // because the preview is loaded first before the actual content is gotten from the
+    // server. If this is a preview, do nothing
+    if (this.data.get('cached') === '1') return
+    this.data.set('cached', '1')
+
     this.selectedFilter = this.selectedFilterTarget.value
     this.selectedCurrencyPair = this.selectedCurrencyPairTarget.value
     this.numberOfRows = this.selectedNumTarget.value

--- a/web/public/js/controllers/mempool_controller.js
+++ b/web/public/js/controllers/mempool_controller.js
@@ -15,7 +15,6 @@ import Zoom from '../helpers/zoom_helper'
 import { animationFrame } from '../helpers/animation_helper'
 
 const Dygraph = require('../vendor/dygraphs.min.js')
-let initialized = false
 
 export default class extends Controller {
   static get targets () {
@@ -30,9 +29,11 @@ export default class extends Controller {
   }
 
   initialize () {
-    if (initialized) {
-      return
-    }
+    // Turbolinks' cache control causes the initialize method to be fired multiple time
+    // because the preview is loaded first before the actual content is gotten from the
+    // server. If this is a preview, do nothing
+    if (this.data.get('cached') === '1') return
+    this.data.set('cached', '1')
     this.currentPage = parseInt(this.currentPageTarget.getAttribute('data-current-page'))
     if (this.currentPage < 1) {
       this.currentPage = 1
@@ -64,12 +65,6 @@ export default class extends Controller {
       this.setChart()
     } else {
       this.setTable()
-    }
-  }
-
-  disconnect () {
-    if (this.chartsView !== undefined) {
-      this.chartsView.destroy()
     }
   }
 

--- a/web/public/js/controllers/nodes_controller.js
+++ b/web/public/js/controllers/nodes_controller.js
@@ -23,7 +23,6 @@ import humanize from '../helpers/humanize_helper'
 
 const Dygraph = require('../vendor/dygraphs.min.js')
 
-let initialized = false
 const dataTypeNodes = 'nodes'
 const dataTypeVersion = 'version'
 const dataTypeLocation = 'location'
@@ -51,9 +50,12 @@ export default class extends Controller {
   }
 
   initialize () {
-    if (initialized) {
-      return
-    }
+    // Turbolinks' cache control causes the initialize method to be fired multiple time
+    // because the preview is loaded first before the actual content is gotten from the
+    // server. If this is a preview, do nothing
+    if (this.data.get('cached') === '1') return
+    this.data.set('cached', '1')
+
     this.currentPage = parseInt(this.data.get('page')) || 1
     this.pageSize = parseInt(this.data.get('pageSize')) || 20
     this.selectedViewOption = this.data.get('viewOption')

--- a/web/public/js/controllers/pow_controller.js
+++ b/web/public/js/controllers/pow_controller.js
@@ -15,7 +15,6 @@ import { animationFrame } from '../helpers/animation_helper'
 import TurboQuery from '../helpers/turbolinks_helper'
 
 const Dygraph = require('../vendor/dygraphs.min.js')
-let initialized = false
 
 export default class extends Controller {
   static get targets () {
@@ -30,9 +29,12 @@ export default class extends Controller {
   }
 
   initialize () {
-    if (initialized) {
-      return
-    }
+    // Turbolinks' cache control causes the initialize method to be fired multiple time
+    // because the preview is loaded first before the actual content is gotten from the
+    // server. If this is a preview, do nothing
+    if (this.data.get('cached') === '1') return
+    this.data.set('cached', '1')
+
     this.query = new TurboQuery()
     this.settings = TurboQuery.nullTemplate(['chart', 'zoom', 'scale', 'bin', 'axis', 'dataType'])
     this.query.update(this.settings)

--- a/web/public/js/controllers/propagation_controller.js
+++ b/web/public/js/controllers/propagation_controller.js
@@ -16,7 +16,6 @@ import Zoom from '../helpers/zoom_helper'
 import { animationFrame } from '../helpers/animation_helper'
 
 const Dygraph = require('../vendor/dygraphs.min.js')
-let initialized = false
 
 const voteLoadingHtml = '<tr><td colspan="7"><div class="h-loader">Loading...</div></td></tr>'
 
@@ -38,9 +37,12 @@ export default class extends Controller {
   }
 
   initialize () {
-    if (initialized) {
-      return
-    }
+    // Turbolinks' cache control causes the initialize method to be fired multiple time
+    // because the preview is loaded first before the actual content is gotten from the
+    // server. If this is a preview, do nothing
+    if (this.data.get('cached') === '1') return
+    this.data.set('cached', '1')
+
     this.currentPage = parseInt(this.currentPageTarget.getAttribute('data-current-page'))
     if (this.currentPage < 1) {
       this.currentPage = 1

--- a/web/public/js/controllers/vsp_controller.js
+++ b/web/public/js/controllers/vsp_controller.js
@@ -15,7 +15,6 @@ import Zoom from '../helpers/zoom_helper'
 import { animationFrame } from '../helpers/animation_helper'
 
 const Dygraph = require('../vendor/dygraphs.min.js')
-let initialized = false
 
 export default class extends Controller {
   static get targets () {
@@ -31,9 +30,12 @@ export default class extends Controller {
   }
 
   initialize () {
-    if (initialized) {
-      return
-    }
+    // Turbolinks' cache control causes the initialize method to be fired multiple time
+    // because the preview is loaded first before the actual content is gotten from the
+    // server. If this is a preview, do nothing
+    if (this.data.get('cached') === '1') return
+    this.data.set('cached', '1')
+
     this.query = new TurboQuery()
     this.settings = TurboQuery.nullTemplate(['chart', 'zoom', 'scale', 'bin', 'axis', 'dataType'])
     this.query.update(this.settings)


### PR DESCRIPTION
This PR fixed the auto-refresh issue on all the pages. 
The issue was as a result of how turbolinks shows a preview of cached page before replacing it with a fresh version from the server.
A logic for detecting when the page is loading in preview mode is introduced on all pages and the initialize method which was called multiple times is aborted in preview mode.