### PR TITLE
Remote propagation database

### DIFF
--- a/config.go
+++ b/config.go
@@ -173,9 +173,13 @@ type config struct {
 	// Mempool
 	MempoolInterval float64 `long:"mempoolinterval" description:"The duration of time between mempool collection"`
 
-	// sync
-	SyncDatabases []string `long:"syncdatabase" description:"Database with external block propagation entry for comparison. Must comatain block and vote tables"`
-
+	// Propagation
+	PropDBHost    []string `long:"propdbhost" description:"Propagation database host"`
+	PropDBPort    []string `long:"propdbport" description:"Propagation database port"`
+	PropDBUser    []string `long:"propdbuser" description:"Propagation database username"`
+	PropDBPass    []string `long:"propdbpass" description:"Propagation database password"`
+	PropDBName    []string `long:"propdbname" description:"Database with external block propagation entry for comparison. Must comatain block and vote tables"`
+	
 	// pow
 	DisabledPows []string `long:"disabledpow" description:"Disable data collection for this Pow"`
 	PowInterval  int64    `long:"powinterval" description:"Collection interval for Pow"`

--- a/config.go
+++ b/config.go
@@ -174,12 +174,12 @@ type config struct {
 	MempoolInterval float64 `long:"mempoolinterval" description:"The duration of time between mempool collection"`
 
 	// Propagation
-	PropDBHost    []string `long:"propdbhost" description:"Propagation database host"`
-	PropDBPort    []string `long:"propdbport" description:"Propagation database port"`
-	PropDBUser    []string `long:"propdbuser" description:"Propagation database username"`
-	PropDBPass    []string `long:"propdbpass" description:"Propagation database password"`
-	PropDBName    []string `long:"propdbname" description:"Database with external block propagation entry for comparison. Must comatain block and vote tables"`
-	
+	PropDBHost []string `long:"propdbhost" description:"Propagation database host"`
+	PropDBPort []string `long:"propdbport" description:"Propagation database port"`
+	PropDBUser []string `long:"propdbuser" description:"Propagation database username"`
+	PropDBPass []string `long:"propdbpass" description:"Propagation database password"`
+	PropDBName []string `long:"propdbname" description:"Database with external block propagation entry for comparison. Must comatain block and vote tables"`
+
 	// pow
 	DisabledPows []string `long:"disabledpow" description:"Disable data collection for this Pow"`
 	PowInterval  int64    `long:"powinterval" description:"Collection interval for Pow"`

--- a/director.go
+++ b/director.go
@@ -95,9 +95,9 @@ func setupModules(ctx context.Context, cfg *config, client *dcrd.Dcrd, server *w
 	if cfg.EnablePropagation {
 		var syncDbs = map[string]propagation.Store{}
 		//register instances
-		for i := 0; i < len(cfg.SyncDatabases); i++ {
-			databaseName := cfg.SyncDatabases[i]
-			syncDb, err := postgres.NewPgDb(cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBPass,
+		for i := 0; i < len(cfg.PropDBName); i++ {
+			databaseName := cfg.PropDBName[i]
+			syncDb, err := postgres.NewPgDb(cfg.PropDBHost[i], cfg.PropDBPort[i], cfg.PropDBUser[i], cfg.PropDBPass[i],
 				databaseName, cfg.DebugLevel == "debug")
 			if err != nil {
 				return err

--- a/sample-pdanalytics.conf
+++ b/sample-pdanalytics.conf
@@ -82,9 +82,13 @@
 ; The maximum number of failed connections before a node is marked as down
 ;max-peer-connection-failure = 3
 
-;Database with external block propagation entry for comparison. Must comatain block and vote tables
-;syncdatabase = pdanalytics2
-;syncdatabase = pdanalytics3
+;Database info with external block propagation entry for comparison.
+; Must comatain block and vote tables
+;propdbhost=localhost
+;propdbport=5432
+;propdbuser=postgres
+;propdbpass=postgres
+;propdbname=pdanalytics2
 
 ; Enable/Disable the proposals module from running
 ;proposals=1 

--- a/sample-pdanalytics.conf
+++ b/sample-pdanalytics.conf
@@ -83,7 +83,7 @@
 ;max-peer-connection-failure = 3
 
 ;Database info with external block propagation entry for comparison.
-; Must comatain block and vote tables
+;Must comatain block and vote tables
 ;propdbhost=localhost
 ;propdbport=5432
 ;propdbuser=postgres

--- a/sample-propagation-pdanalytics.conf
+++ b/sample-propagation-pdanalytics.conf
@@ -86,9 +86,19 @@ snapshot-http=0
 ; The maximum number of failed connections before a node is marked as down
 ;max-peer-connection-failure = 3
 
-;Database with external block propagation entry for comparison. Must comatain block and vote tables
-;syncdatabase = pdanalytics2
-;syncdatabase = pdanalytics3
+;Database info with external block propagation entry for comparison.
+;Must comatain block and vote tables
+;propdbhost=localhost
+;propdbport=5432
+;propdbuser=postgres
+;propdbpass=postgres
+;propdbname=pdanalytics2
+
+;propdbhost=localhost
+;propdbport=5432
+;propdbuser=postgres
+;propdbpass=postgres
+;propdbname=pdanalytics3
 
 ; Enable/Disable the proposals module from running
 proposals=0


### PR DESCRIPTION
Closes #37 
This PR adds support for comparison the propagation data against a remote database. 
Multiple entries can be added to the config file, and the user can specify the host, database name, username, and password for each entry.