### PR TITLE
Locked fund in reward calculator

### DIFF
--- a/stakingreward/stakingreward.go
+++ b/stakingreward/stakingreward.go
@@ -203,6 +203,7 @@ func (calc *Calculator) simulateStakingReward(numberOfDays float64, startingDCRB
 
 		simulationTable[len(simulationTable)-1].TicketPrice = TicketPrice
 		simulationTable[len(simulationTable)-1].TicketsPurchased = ticketsPurchased
+		simulationTable[len(simulationTable)-1].LockedFund = ticketsPurchased * TicketPrice
 
 		DCRBalance -= (TicketPrice * ticketsPurchased)
 
@@ -223,7 +224,6 @@ func (calc *Calculator) simulateStakingReward(numberOfDays float64, startingDCRB
 			SimDay:       day,
 			DCRBalance:   DCRBalance,
 			Reward:       (StakeRewardAtBlock(simblock) * ticketsPurchased),
-			ReturnedFund: (TicketPrice * ticketsPurchased),
 			TicketPrice:  TheoreticalTicketPrice(simblock) * TicketAdjustmentFactor,
 		})
 

--- a/stakingreward/types.go
+++ b/stakingreward/types.go
@@ -33,5 +33,5 @@ type simulationRow struct {
 	DCRBalance       float64 `json:"dcr_balance"`
 	TicketsPurchased float64 `json:"tickets_purchased"`
 	Reward           float64 `json:"reward"`
-	ReturnedFund     float64 `json:"returned_fund"`
+	LockedFund     float64 `json:"locked_fund"`
 }

--- a/views/stakingreward.tmpl
+++ b/views/stakingreward.tmpl
@@ -77,7 +77,7 @@
                 <th style="padding: 10px 8px;">Date</th>
                 <th style="padding: 10px 8px;">Height</th>
                 <th style="padding: 10px 8px; max-width: 77px;">Tickets Price Avg  <small>(<span class="text-secondary">DCR</span>)</small></th>
-                <th style="padding: 10px 8px; max-width: 66px;">Returned Fund <small>(<span class="text-secondary">DCR</span>)</small></th>
+                <th style="padding: 10px 8px; max-width: 66px;">Locked Fund <small>(<span class="text-secondary">DCR</span>)</small></th>
                 <th style="padding: 10px 8px; max-width: 64px;">Reward  <small>(<span class="text-secondary">DCR</span>)</small></th>
                 <th style="padding: 10px 8px; max-width: 77px;">Total Balance  <small>(<span class="text-secondary">DCR</span>)</small></th>
                 <th style="padding: 10px 8px; max-width: 51px;">% Gained</th>

--- a/web/public/js/controllers/stakingreward_controller.js
+++ b/web/public/js/controllers/stakingreward_controller.js
@@ -159,7 +159,7 @@ export default class extends Controller {
         fields[0].innerText = date.format('YYYY-MM-DD')
         fields[1].innerText = item.height
         fields[2].innerText = item.ticket_price.toFixed(2)
-        fields[3].innerText = item.returned_fund.toFixed(2)
+        fields[3].innerText = item.locked_fund.toFixed(2)
         fields[4].innerText = item.reward.toFixed(2)
         fields[5].innerText = item.dcr_balance.toFixed(2)
         fields[6].innerText = (100 * (item.dcr_balance - amount) / amount).toFixed(2)


### PR DESCRIPTION
This PR removed the `returned fund` column and added a column for the `Locked fund` on the staking reward page